### PR TITLE
Add initial RAIF runtime skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts
+build/
+*.o
+*.so
+*.a
+*.exe
+
+# IDE files
+*.vscode/
+*~
+*.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.10)
+project(raif LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Source files
+file(GLOB RAIF_SRCS
+    src/runtime/*.cpp
+    src/ops/*.cpp
+)
+
+add_library(raif STATIC ${RAIF_SRCS})
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(raif PRIVATE -mavx2 -mfma)
+endif()
+
+# Public headers
+# Expose include directory for downstream consumers
+
+# Add this directory for header search path
+
+target_include_directories(raif PUBLIC include)
+
+enable_testing()
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# raif
+# RAIF
+
+RAIF (Runtime for AI Inference) is a lightweight runtime designed to
+accelerate AI model inference across different hardware targets. The
+goal of this project is to provide a collection of optimized kernels
+and a simple runtime that selects the best implementation based on the
+underlying processor features (e.g. AVX2, SSE, etc.).
+
+## Directory Structure
+
+- `src/` - C++ implementation of the runtime and operators.
+- `include/` - Public headers.
+- `test/` - Unit tests and examples built with CMake.
+- `examples/` - Sample applications (empty for now).
+- `docs/` - Documentation (design notes, guides).
+- `scripts/` - Helper scripts (build, tooling, etc.).
+
+## Building
+
+This project uses CMake:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+ctest
+```
+
+`ctest` will build and run the sample test located in `test/`.
+
+## Status
+
+This repository currently contains minimal sample code to demonstrate
+how the runtime might be organized. Real operator implementations and
+additional hardware support will be added in the future.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,8 @@
+# RAIF Architecture
+
+This document outlines the initial directory structure and goals of the
+RAIF runtime. The system is intended to provide CPU/GPU/NPU optimized
+kernels with automatic dispatch based on hardware capabilities.
+
+Currently only a minimal set of CPU operations are provided as a proof
+of concept.

--- a/examples/simple_example.cpp
+++ b/examples/simple_example.cpp
@@ -1,0 +1,13 @@
+#include "raif/runtime.h"
+#include <iostream>
+
+int main() {
+    raif::init();
+    const int M=1, N=1, K=4;
+    float A[K] = {1,2,3,4};
+    float B[K] = {5,6,7,8};
+    float C[1] = {0};
+    raif::matmul(C, A, B, M, N, K);
+    std::cout << "Result: " << C[0] << std::endl;
+    return 0;
+}

--- a/include/raif/relu.h
+++ b/include/raif/relu.h
@@ -1,0 +1,11 @@
+#ifndef RAIF_RELU_H
+#define RAIF_RELU_H
+
+namespace raif {
+
+void relu_ref(float* dst, const float* src, int len);
+void relu_avx2(float* dst, const float* src, int len);
+
+}
+
+#endif // RAIF_RELU_H

--- a/include/raif/runtime.h
+++ b/include/raif/runtime.h
@@ -1,0 +1,12 @@
+#ifndef RAIF_RUNTIME_H
+#define RAIF_RUNTIME_H
+
+namespace raif {
+
+void init();
+
+void matmul(float* C, const float* A, const float* B, int M, int N, int K);
+
+} // namespace raif
+
+#endif // RAIF_RUNTIME_H

--- a/src/ops/relu.cpp
+++ b/src/ops/relu.cpp
@@ -1,0 +1,22 @@
+#include "raif/relu.h"
+#include <algorithm>
+#include <immintrin.h>
+
+namespace raif {
+
+void relu_ref(float* dst, const float* src, int len) {
+    for(int i=0;i<len;++i) dst[i] = std::max(0.0f, src[i]);
+}
+
+void relu_avx2(float* dst, const float* src, int len) {
+    int i=0;
+    __m256 zero = _mm256_setzero_ps();
+    for(; i+8<=len; i+=8) {
+        __m256 v = _mm256_loadu_ps(src + i);
+        __m256 r = _mm256_max_ps(zero, v);
+        _mm256_storeu_ps(dst + i, r);
+    }
+    for(; i<len; ++i) dst[i] = std::max(0.0f, src[i]);
+}
+
+} // namespace raif

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -1,0 +1,62 @@
+#include "raif/runtime.h"
+#include <immintrin.h>
+#include <cstring>
+
+namespace raif {
+
+namespace {
+using MatMulFn = void(*)(float*, const float*, const float*, int, int, int);
+
+void matmul_ref(float* C, const float* A, const float* B, int M, int N, int K) {
+    for(int i=0;i<M;i++) {
+        for(int j=0;j<N;j++) {
+            float sum = 0.0f;
+            for(int k=0;k<K;k++) {
+                sum += A[i*K+k] * B[k*N+j];
+            }
+            C[i*N+j] = sum;
+        }
+    }
+}
+
+void matmul_avx2(float* C, const float* A, const float* B, int M, int N, int K) {
+    // Simple AVX2 implementation with 8-float vectors
+    for(int i=0;i<M;i++) {
+        for(int j=0;j<N;j++) {
+            __m256 sum = _mm256_setzero_ps();
+            int k=0;
+            for(; k+8<=K; k+=8) {
+                __m256 va = _mm256_loadu_ps(A + i*K + k);
+                // Broadcast B element since column stride may not be contiguous
+                __m256 vbroadcast = _mm256_set1_ps(*(B + k*N + j));
+                sum = _mm256_fmadd_ps(va, vbroadcast, sum);
+            }
+            float scalar_sum = 0.0f;
+            for(;k<K;k++) {
+                scalar_sum += A[i*K+k] * B[k*N+j];
+            }
+            alignas(32) float tmp[8];
+            _mm256_store_ps(tmp, sum);
+            for(int t=0;t<8;t++) scalar_sum += tmp[t];
+            C[i*N+j] = scalar_sum;
+        }
+    }
+}
+
+MatMulFn matmul_impl = matmul_ref;
+
+} // anonymous namespace
+
+void init() {
+#ifdef __x86_64__
+    if (__builtin_cpu_supports("avx2")) {
+        matmul_impl = matmul_avx2;
+    }
+#endif
+}
+
+void matmul(float* C, const float* A, const float* B, int M, int N, int K) {
+    matmul_impl(C, A, B, M, N, K);
+}
+
+} // namespace raif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(raif_test test_main.cpp)
+target_link_libraries(raif_test PRIVATE raif)
+add_test(NAME raif_test COMMAND raif_test)

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include "raif/runtime.h"
+
+int main() {
+    raif::init();
+    const int M = 2, N = 2, K = 2;
+    float A[M*K] = {1,2,3,4};
+    float B[K*N] = {5,6,7,8};
+    float C[M*N] = {0};
+    raif::matmul(C, A, B, M, N, K);
+    for(int i=0;i<M*N;i++) std::cout << C[i] << " ";
+    std::cout << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add project README and docs
- setup CMake build and test directories
- implement minimal runtime with AVX2 matmul and relu ops
- provide example and unit test

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`
