### PR TITLE
Add additional activation functions

### DIFF
--- a/include/runtime/activation.h
+++ b/include/runtime/activation.h
@@ -6,6 +6,15 @@ namespace raif {
 void relu_ref(float* dst, const float* src, int len);
 void relu_avx2(float* dst, const float* src, int len);
 
+void gelu_ref(float* dst, const float* src, int len);
+void gelu_avx2(float* dst, const float* src, int len);
+
+void sigmoid_ref(float* dst, const float* src, int len);
+void sigmoid_avx2(float* dst, const float* src, int len);
+
+void softmax_ref(float* dst, const float* src, int len);
+void softmax_avx2(float* dst, const float* src, int len);
+
 }
 
 #endif // RAIF_ACTIVATION_H

--- a/src/ops/activation.cpp
+++ b/src/ops/activation.cpp
@@ -1,5 +1,6 @@
 #include "runtime/activation.h"
 #include <algorithm>
+#include <cmath>
 #include <immintrin.h>
 
 namespace raif {
@@ -17,6 +18,44 @@ void relu_avx2(float* dst, const float* src, int len) {
         _mm256_storeu_ps(dst + i, r);
     }
     for(; i<len; ++i) dst[i] = std::max(0.0f, src[i]);
+}
+
+void gelu_ref(float* dst, const float* src, int len) {
+    const float c = std::sqrt(2.0f / M_PI);
+    for(int i=0;i<len;++i) {
+        float x = src[i];
+        float t = c * (x + 0.044715f * x * x * x);
+        dst[i] = 0.5f * x * (1.0f + std::tanh(t));
+    }
+}
+
+void gelu_avx2(float* dst, const float* src, int len) {
+    gelu_ref(dst, src, len);
+}
+
+void sigmoid_ref(float* dst, const float* src, int len) {
+    for(int i=0;i<len;++i) {
+        dst[i] = 1.0f / (1.0f + std::exp(-src[i]));
+    }
+}
+
+void sigmoid_avx2(float* dst, const float* src, int len) {
+    sigmoid_ref(dst, src, len);
+}
+
+void softmax_ref(float* dst, const float* src, int len) {
+    float max_v = src[0];
+    for(int i=1;i<len;++i) max_v = std::max(max_v, src[i]);
+    float sum = 0.0f;
+    for(int i=0;i<len;++i) {
+        dst[i] = std::exp(src[i] - max_v);
+        sum += dst[i];
+    }
+    for(int i=0;i<len;++i) dst[i] /= sum;
+}
+
+void softmax_avx2(float* dst, const float* src, int len) {
+    softmax_ref(dst, src, len);
 }
 
 } // namespace raif

--- a/src/ops/softmax.cpp
+++ b/src/ops/softmax.cpp
@@ -1,1 +1,0 @@
-// Placeholder

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "runtime/engine.h"
+#include "runtime/activation.h"
 
 int main() {
     raif::init();
@@ -10,5 +11,13 @@ int main() {
     raif::matmul(C, A, B, M, N, K);
     for(int i=0;i<M*N;i++) std::cout << C[i] << " ";
     std::cout << std::endl;
+
+    float X[4] = {-1.0f, 0.0f, 1.0f, 2.0f};
+    float Y[4];
+    raif::relu_ref(Y, X, 4);
+    raif::gelu_ref(Y, X, 4);
+    raif::sigmoid_ref(Y, X, 4);
+    raif::softmax_ref(Y, X, 4);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- expand activation header to include GELU, sigmoid, and softmax
- implement reference versions for new activations
- remove old placeholder softmax.cpp
- update simple test to invoke new functions

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`
