### PR TITLE
Add PyTorch SimpleResNet example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,10 @@
-# Placeholder examples CMake
+cmake_minimum_required(VERSION 3.10)
+
+find_package(Torch REQUIRED)
+
+add_executable(image_classification
+    image_classification/image_classification.cpp
+)
+
+target_link_libraries(image_classification PRIVATE ${TORCH_LIBRARIES})
+set_property(TARGET image_classification PROPERTY CXX_STANDARD 17)

--- a/examples/image_classification/image_classification.cpp
+++ b/examples/image_classification/image_classification.cpp
@@ -1,2 +1,23 @@
-// Placeholder example
-int main() { return 0; }
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <iostream>
+
+int main() {
+    try {
+        // Load the traced PyTorch model
+        torch::jit::script::Module module = torch::jit::load("simple_resnet.pt");
+        module.eval();
+
+        // Prepare a dummy input tensor
+        std::vector<torch::jit::IValue> inputs;
+        inputs.push_back(torch::randn({1, 3, 32, 32}));
+
+        // Run the model
+        at::Tensor output = module.forward(inputs).toTensor();
+        std::cout << output.sizes() << std::endl;
+    } catch (const c10::Error& e) {
+        std::cerr << "Error loading or running the model: " << e.what() << std::endl;
+        return -1;
+    }
+    return 0;
+}

--- a/examples/image_classification/simple_resnet.py
+++ b/examples/image_classification/simple_resnet.py
@@ -1,0 +1,55 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class ResidualBlock(nn.Module):
+    def __init__(self, in_channels, out_channels, stride=1, downsample=None):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=3,
+                               stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=3,
+                               stride=1, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(out_channels)
+        self.downsample = downsample
+
+    def forward(self, x):
+        identity = x
+        out = self.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        if self.downsample is not None:
+            identity = self.downsample(x)
+        out += identity
+        out = self.relu(out)
+        return out
+
+class SimpleResNet(nn.Module):
+    def __init__(self, num_classes=10):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(64)
+        self.relu = nn.ReLU(inplace=True)
+        self.layer1 = nn.Sequential(
+            ResidualBlock(64, 64),
+            ResidualBlock(64, 64)
+        )
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(64, num_classes)
+
+    def forward(self, x):
+        out = self.relu(self.bn(self.conv(x)))
+        out = self.layer1(out)
+        out = self.pool(out)
+        out = torch.flatten(out, 1)
+        out = self.fc(out)
+        return out
+
+if __name__ == "__main__":
+    model = SimpleResNet(num_classes=10)
+    model.eval()
+    dummy = torch.randn(1, 3, 32, 32)
+    traced = torch.jit.trace(model, dummy)
+    traced.save("simple_resnet.pt")
+    out = traced(dummy)
+    print(out.shape)


### PR DESCRIPTION
## Summary
- add a python implementation of `SimpleResNet` that can export a TorchScript model
- update `image_classification.cpp` to load the TorchScript file and run inference
- provide a CMake file for building the example with LibTorch

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`