### PR TITLE
Add manual ResNet inference example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,3 +8,9 @@ add_executable(image_classification
 
 target_link_libraries(image_classification PRIVATE ${TORCH_LIBRARIES})
 set_property(TARGET image_classification PROPERTY CXX_STANDARD 17)
+
+add_executable(simple_resnet_manual
+    image_classification/simple_resnet_manual.cpp
+)
+target_link_libraries(simple_resnet_manual PRIVATE raif)
+set_property(TARGET simple_resnet_manual PROPERTY CXX_STANDARD 17)

--- a/examples/image_classification/simple_resnet_manual.cpp
+++ b/examples/image_classification/simple_resnet_manual.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <vector>
+#include <cstdlib>
+#include <cmath>
+#include "runtime/convolution.h"
+#include "runtime/batchnorm.h"
+#include "runtime/activation.h"
+#include "runtime/pooling.h"
+#include "runtime/fully_connected.h"
+#include "runtime/flatten.h"
+
+using namespace raif;
+
+// Simple helper to initialize weights
+static void init_vector(std::vector<float>& v) {
+    for(auto& x : v) {
+        x = static_cast<float>(std::rand()) / RAND_MAX - 0.5f;
+    }
+}
+
+int main() {
+    const int batch = 1;
+    const int in_c = 3;
+    const int h = 32;
+    const int w = 32;
+
+    std::vector<float> input(batch*in_c*h*w, 1.0f);
+
+    // First conv layer
+    std::vector<float> conv_w(64*in_c*3*3);
+    init_vector(conv_w);
+    std::vector<float> conv_mean(64, 0.0f), conv_var(64, 1.0f);
+    std::vector<float> conv_weight(64, 1.0f), conv_bias(64, 0.0f);
+
+    std::vector<float> x(batch*64*h*w);
+    conv2d_3x3_winograd(input.data(), conv_w.data(), x.data(), batch, in_c, 64, h, w);
+    std::vector<float> tmp(batch*64*h*w);
+    batchnorm_forward(tmp.data(), x.data(), conv_mean.data(), conv_var.data(), conv_weight.data(), conv_bias.data(), 1e-5f, batch, 64, h, w);
+    relu_avx2(x.data(), tmp.data(), tmp.size());
+
+    // Residual block 1
+    std::vector<float> rb1_w1(64*64*3*3), rb1_w2(64*64*3*3);
+    init_vector(rb1_w1); init_vector(rb1_w2);
+    std::vector<float> rb1_mean1(64,0.0f), rb1_var1(64,1.0f), rb1_wt1(64,1.0f), rb1_bs1(64,0.0f);
+    std::vector<float> rb1_mean2(64,0.0f), rb1_var2(64,1.0f), rb1_wt2(64,1.0f), rb1_bs2(64,0.0f);
+
+    std::vector<float> rb1_out(batch*64*h*w);
+    conv2d_3x3_winograd(x.data(), rb1_w1.data(), rb1_out.data(), batch, 64, 64, h, w);
+    batchnorm_forward(tmp.data(), rb1_out.data(), rb1_mean1.data(), rb1_var1.data(), rb1_wt1.data(), rb1_bs1.data(), 1e-5f, batch, 64, h, w);
+    relu_avx2(rb1_out.data(), tmp.data(), tmp.size());
+    conv2d_3x3_winograd(rb1_out.data(), rb1_w2.data(), tmp.data(), batch, 64, 64, h, w);
+    batchnorm_forward(rb1_out.data(), tmp.data(), rb1_mean2.data(), rb1_var2.data(), rb1_wt2.data(), rb1_bs2.data(), 1e-5f, batch, 64, h, w);
+    for(size_t i=0;i<rb1_out.size();++i) rb1_out[i] += x[i];
+    relu_avx2(x.data(), rb1_out.data(), rb1_out.size());
+
+    // Residual block 2
+    std::vector<float> rb2_w1(64*64*3*3), rb2_w2(64*64*3*3);
+    init_vector(rb2_w1); init_vector(rb2_w2);
+    std::vector<float> rb2_mean1(64,0.0f), rb2_var1(64,1.0f), rb2_wt1(64,1.0f), rb2_bs1(64,0.0f);
+    std::vector<float> rb2_mean2(64,0.0f), rb2_var2(64,1.0f), rb2_wt2(64,1.0f), rb2_bs2(64,0.0f);
+
+    conv2d_3x3_winograd(x.data(), rb2_w1.data(), rb1_out.data(), batch, 64, 64, h, w);
+    batchnorm_forward(tmp.data(), rb1_out.data(), rb2_mean1.data(), rb2_var1.data(), rb2_wt1.data(), rb2_bs1.data(), 1e-5f, batch, 64, h, w);
+    relu_avx2(rb1_out.data(), tmp.data(), tmp.size());
+    conv2d_3x3_winograd(rb1_out.data(), rb2_w2.data(), tmp.data(), batch, 64, 64, h, w);
+    batchnorm_forward(rb1_out.data(), tmp.data(), rb2_mean2.data(), rb2_var2.data(), rb2_wt2.data(), rb2_bs2.data(), 1e-5f, batch, 64, h, w);
+    for(size_t i=0;i<rb1_out.size();++i) rb1_out[i] += x[i];
+    relu_avx2(x.data(), rb1_out.data(), rb1_out.size());
+
+    // Global average pool
+    avg_pool2d_ref(tmp.data(), x.data(), batch, 64, h, w, h, w, h, w, 0, 0);
+
+    // Flatten
+    std::vector<float> flat(batch*64);
+    flatten(flat.data(), tmp.data(), batch, 64, 1, 1);
+
+    // Fully connected
+    std::vector<float> fc_w(10*64); init_vector(fc_w);
+    std::vector<float> fc_b(10, 0.0f);
+    std::vector<float> out(batch*10);
+    fully_connected(out.data(), flat.data(), fc_w.data(), fc_b.data(), batch, 10, 64);
+
+    std::cout << "Output:";
+    for(int i=0;i<10;i++) std::cout << " " << out[i];
+    std::cout << std::endl;
+    return 0;
+}

--- a/include/runtime/batchnorm.h
+++ b/include/runtime/batchnorm.h
@@ -1,0 +1,28 @@
+#ifndef RAIF_BATCHNORM_H
+#define RAIF_BATCHNORM_H
+
+namespace raif {
+
+// Batch normalization for inference.
+// Parameters:
+//  input  - [N, C, H, W]
+//  mean   - [C]
+//  var    - [C]
+//  weight - [C] (can be nullptr)
+//  bias   - [C] (can be nullptr)
+//  epsilon - small constant for numerical stability
+void batchnorm_forward(float* output,
+                       const float* input,
+                       const float* mean,
+                       const float* var,
+                       const float* weight,
+                       const float* bias,
+                       float epsilon,
+                       int N,
+                       int C,
+                       int H,
+                       int W);
+
+} // namespace raif
+
+#endif // RAIF_BATCHNORM_H

--- a/include/runtime/flatten.h
+++ b/include/runtime/flatten.h
@@ -1,0 +1,16 @@
+#ifndef RAIF_FLATTEN_H
+#define RAIF_FLATTEN_H
+
+namespace raif {
+
+// Flatten the input tensor to 2D [N, C*H*W].
+void flatten(float* output,
+             const float* input,
+             int N,
+             int C,
+             int H,
+             int W);
+
+} // namespace raif
+
+#endif // RAIF_FLATTEN_H

--- a/src/ops/batchnorm.cpp
+++ b/src/ops/batchnorm.cpp
@@ -1,0 +1,54 @@
+#include "runtime/batchnorm.h"
+#include <cmath>
+#include <immintrin.h>
+
+namespace raif {
+
+void batchnorm_forward(float* output,
+                       const float* input,
+                       const float* mean,
+                       const float* var,
+                       const float* weight,
+                       const float* bias,
+                       float epsilon,
+                       int N,
+                       int C,
+                       int H,
+                       int W) {
+    int spatial = H * W;
+    for(int n=0; n<N; ++n) {
+        for(int c=0; c<C; ++c) {
+            float m = mean[c];
+            float ivar = 1.0f / std::sqrt(var[c] + epsilon);
+            float w = weight ? weight[c] : 1.0f;
+            float b = bias ? bias[c] : 0.0f;
+            const float* src = input + ((n*C + c) * spatial);
+            float* dst = output + ((n*C + c) * spatial);
+#ifdef __AVX2__
+            __m256 vm = _mm256_set1_ps(m);
+            __m256 vivar = _mm256_set1_ps(ivar);
+            __m256 vw = _mm256_set1_ps(w);
+            __m256 vb = _mm256_set1_ps(b);
+            int i = 0;
+            for(; i + 8 <= spatial; i += 8) {
+                __m256 v = _mm256_loadu_ps(src + i);
+                __m256 norm = _mm256_mul_ps(_mm256_sub_ps(v, vm), vivar);
+                __m256 out = _mm256_fmadd_ps(norm, vw, vb);
+                _mm256_storeu_ps(dst + i, out);
+            }
+            for(; i < spatial; ++i) {
+                float norm = (src[i] - m) * ivar;
+                dst[i] = norm * w + b;
+            }
+#else
+            for(int i=0; i<spatial; ++i) {
+                float norm = (src[i] - m) * ivar;
+                dst[i] = norm * w + b;
+            }
+#endif
+        }
+    }
+}
+
+} // namespace raif
+

--- a/src/ops/flatten.cpp
+++ b/src/ops/flatten.cpp
@@ -1,0 +1,12 @@
+#include "runtime/flatten.h"
+#include <cstring>
+
+namespace raif {
+
+void flatten(float* output, const float* input,
+             int N, int C, int H, int W) {
+    std::memcpy(output, input, sizeof(float) * N * C * H * W);
+}
+
+} // namespace raif
+


### PR DESCRIPTION
## Summary
- implement batch normalization and flatten operations
- create a manual ResNet inference example using RAIF ops
- enable building the new example via CMake

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`
