### PR TITLE
Add stride/padding support to convolution

### DIFF
--- a/include/runtime/convolution.h
+++ b/include/runtime/convolution.h
@@ -4,12 +4,24 @@
 namespace raif {
 
 void conv2d_3x3_winograd(const float* input, const float* filter, float* output,
-                          int batches, int in_channels, int out_channels,
-                          int height, int width);
+                         int batches, int in_channels, int out_channels,
+                         int height, int width);
 
 void conv2d_5x5_winograd(const float* input, const float* filter, float* output,
-                          int batches, int in_channels, int out_channels,
-                          int height, int width);
+                         int batches, int in_channels, int out_channels,
+                         int height, int width);
+
+enum PaddingType {
+    PADDING_ZERO,
+    PADDING_VALID
+};
+
+void conv2d_ref(const float* input, const float* filter, float* output,
+                int batches, int in_channels, int out_channels,
+                int height, int width,
+                int kernel_h, int kernel_w,
+                int stride,
+                PaddingType padding);
 
 } // namespace raif
 

--- a/src/ops/convolution.cpp
+++ b/src/ops/convolution.cpp
@@ -20,5 +20,43 @@ void conv2d_5x5_winograd(const float* input, const float* filter, float* output,
                         height, width);
 }
 
+void conv2d_ref(const float* input, const float* filter, float* output,
+                int batches, int in_channels, int out_channels,
+                int height, int width,
+                int kernel_h, int kernel_w,
+                int stride,
+                PaddingType padding) {
+    int pad_h = (padding == PADDING_ZERO) ? (kernel_h / 2) : 0;
+    int pad_w = (padding == PADDING_ZERO) ? (kernel_w / 2) : 0;
+
+    int out_h = (height + 2 * pad_h - kernel_h) / stride + 1;
+    int out_w = (width + 2 * pad_w - kernel_w) / stride + 1;
+
+    for(int b=0; b<batches; ++b) {
+        for(int oc=0; oc<out_channels; ++oc) {
+            for(int oh=0; oh<out_h; ++oh) {
+                for(int ow=0; ow<out_w; ++ow) {
+                    float sum = 0.0f;
+                    for(int ic=0; ic<in_channels; ++ic) {
+                        for(int kh=0; kh<kernel_h; ++kh) {
+                            int ih = oh * stride - pad_h + kh;
+                            if(ih < 0 || ih >= height) continue;
+                            for(int kw=0; kw<kernel_w; ++kw) {
+                                int iw = ow * stride - pad_w + kw;
+                                if(iw < 0 || iw >= width) continue;
+                                int in_idx = ((b*in_channels + ic)*height + ih)*width + iw;
+                                int f_idx = ((oc*in_channels + ic)*kernel_h + kh)*kernel_w + kw;
+                                sum += input[in_idx] * filter[f_idx];
+                            }
+                        }
+                    }
+                    int out_idx = ((b*out_channels + oc)*out_h + oh)*out_w + ow;
+                    output[out_idx] = sum;
+                }
+            }
+        }
+    }
+}
+
 } // namespace raif
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "runtime/engine.h"
 #include "runtime/activation.h"
+#include "runtime/convolution.h"
 
 int main() {
     raif::init();
@@ -18,6 +19,27 @@ int main() {
     raif::gelu_ref(Y, X, 4);
     raif::sigmoid_ref(Y, X, 4);
     raif::softmax_ref(Y, X, 4);
+
+    // Simple convolution test
+    const int BATCH = 1, IC = 1, OC = 1, H = 4, W = 4;
+    float input[BATCH*IC*H*W] = {
+        1, 2, 3, 4,
+        5, 6, 7, 8,
+        9,10,11,12,
+        13,14,15,16
+    };
+    float filter[1*1*3*3] = {
+        1,0,-1,
+        1,0,-1,
+        1,0,-1
+    };
+    const int KH = 3, KW = 3, STRIDE = 1;
+    float out[BATCH*OC*H*W] = {0};
+    raif::conv2d_ref(input, filter, out,
+                     BATCH, IC, OC, H, W, KH, KW, STRIDE,
+                     raif::PADDING_ZERO);
+    for(int i=0;i<H*W;i++) std::cout << out[i] << " ";
+    std::cout << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend convolution API with stride and padding options
- implement `conv2d_ref` supporting stride 1-5 and zero/valid padding
- add simple convolution usage in test executable

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`
