### PR TITLE
Add wireless DSP operations

### DIFF
--- a/docs/wireless_ops.md
+++ b/docs/wireless_ops.md
@@ -1,0 +1,18 @@
+# Wireless Communication Operations
+
+This document lists basic signal processing algorithms that are often
+used in wireless systems. These operations are added to the RAIF runtime
+so that models can integrate classical DSP steps alongside neural
+network layers.
+
+## Fast Fourier Transform (FFT)
+
+The FFT is required for OFDM modulation and channel estimation. RAIF
+provides a reference radix-2 implementation that can perform both
+forward and inverse transforms.
+
+## Finite Impulse Response (FIR) Filter
+
+FIR filters appear in channel filtering and pulse shaping stages. A
+simple reference implementation is included which computes the convolution
+of an input sequence with a set of coefficients.

--- a/include/runtime/fft.h
+++ b/include/runtime/fft.h
@@ -1,0 +1,13 @@
+#ifndef RAIF_FFT_H
+#define RAIF_FFT_H
+
+#include <complex>
+
+namespace raif {
+
+void fft_ref(std::complex<float>* data, int n);
+void ifft_ref(std::complex<float>* data, int n);
+
+}
+
+#endif // RAIF_FFT_H

--- a/include/runtime/fir.h
+++ b/include/runtime/fir.h
@@ -1,0 +1,11 @@
+#ifndef RAIF_FIR_OP_H
+#define RAIF_FIR_OP_H
+
+namespace raif {
+
+void fir_filter_ref(const float* input, const float* coeffs, float* output,
+                    int length, int num_taps);
+
+}
+
+#endif // RAIF_FIR_OP_H

--- a/kernels/cpu/signal/fft.cpp
+++ b/kernels/cpu/signal/fft.cpp
@@ -1,0 +1,34 @@
+#include "kernels/cpu/signal/fft.h"
+#include <vector>
+#include <cmath>
+
+namespace raif {
+
+static void fft_rec(std::complex<float>* data, int n, bool inverse) {
+    if(n <= 1) return;
+    int half = n / 2;
+    std::vector<std::complex<float>> even(half), odd(half);
+    for(int i=0; i<half; ++i) {
+        even[i] = data[2*i];
+        odd[i] = data[2*i+1];
+    }
+    fft_rec(even.data(), half, inverse);
+    fft_rec(odd.data(), half, inverse);
+    float sign = inverse ? 1.0f : -1.0f;
+    for(int k=0; k<half; ++k) {
+        float angle = 2.0f * static_cast<float>(M_PI) * k / n;
+        std::complex<float> w(std::cos(angle), sign * std::sin(angle));
+        std::complex<float> t = w * odd[k];
+        data[k] = even[k] + t;
+        data[k+half] = even[k] - t;
+    }
+}
+
+void fft_radix2(std::complex<float>* data, int n, bool inverse) {
+    fft_rec(data, n, inverse);
+    if(inverse) {
+        for(int i=0;i<n;++i) data[i] /= static_cast<float>(n);
+    }
+}
+
+} // namespace raif

--- a/kernels/cpu/signal/fft.h
+++ b/kernels/cpu/signal/fft.h
@@ -1,0 +1,12 @@
+#ifndef RAIF_FFT_RADIX2_H
+#define RAIF_FFT_RADIX2_H
+
+#include <complex>
+
+namespace raif {
+
+void fft_radix2(std::complex<float>* data, int n, bool inverse);
+
+} // namespace raif
+
+#endif // RAIF_FFT_RADIX2_H

--- a/kernels/cpu/signal/fir.cpp
+++ b/kernels/cpu/signal/fir.cpp
@@ -1,0 +1,16 @@
+#include "kernels/cpu/signal/fir.h"
+
+namespace raif {
+
+void fir_filter(const float* input, const float* coeffs, float* output,
+                int length, int num_taps) {
+    for(int n=0; n<length; ++n) {
+        float acc = 0.f;
+        for(int k=0; k<num_taps; ++k) {
+            if(n-k >= 0) acc += input[n-k] * coeffs[k];
+        }
+        output[n] = acc;
+    }
+}
+
+} // namespace raif

--- a/kernels/cpu/signal/fir.h
+++ b/kernels/cpu/signal/fir.h
@@ -1,0 +1,11 @@
+#ifndef RAIF_FIR_H
+#define RAIF_FIR_H
+
+namespace raif {
+
+void fir_filter(const float* input, const float* coeffs, float* output,
+                int length, int num_taps);
+
+} // namespace raif
+
+#endif // RAIF_FIR_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB RAIF_OP_SRCS
 )
 file(GLOB RAIF_KERNEL_SRCS
     ../kernels/cpu/winograd/*.cpp
+    ../kernels/cpu/signal/*.cpp
 )
 add_library(raif STATIC
     ${RAIF_CORE_SRCS}

--- a/src/ops/fft.cpp
+++ b/src/ops/fft.cpp
@@ -1,0 +1,14 @@
+#include "runtime/fft.h"
+#include "kernels/cpu/signal/fft.h"
+
+namespace raif {
+
+void fft_ref(std::complex<float>* data, int n) {
+    fft_radix2(data, n, false);
+}
+
+void ifft_ref(std::complex<float>* data, int n) {
+    fft_radix2(data, n, true);
+}
+
+} // namespace raif

--- a/src/ops/fir.cpp
+++ b/src/ops/fir.cpp
@@ -1,0 +1,11 @@
+#include "runtime/fir.h"
+#include "kernels/cpu/signal/fir.h"
+
+namespace raif {
+
+void fir_filter_ref(const float* input, const float* coeffs, float* output,
+                    int length, int num_taps) {
+    fir_filter(input, coeffs, output, length, num_taps);
+}
+
+} // namespace raif

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -2,6 +2,8 @@
 #include "runtime/engine.h"
 #include "runtime/activation.h"
 #include "runtime/convolution.h"
+#include "runtime/fft.h"
+#include "runtime/fir.h"
 
 int main() {
     raif::init();
@@ -40,6 +42,16 @@ int main() {
                         raif::PADDING_ZERO);
     for(int i=0;i<H*W;i++) std::cout << out[i] << " ";
     std::cout << std::endl;
+
+    // Simple FFT/IFFT test
+    std::complex<float> data[4] = {1.0f, 0.0f, -1.0f, 0.0f};
+    raif::fft_ref(data, 4);
+    raif::ifft_ref(data, 4);
+
+    // FIR filter test
+    float coeffs[3] = {0.25f, 0.5f, 0.25f};
+    float fir_out[4];
+    raif::fir_filter_ref(X, coeffs, fir_out, 4, 3);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add reference FFT and FIR filter operations
- implement CPU kernels for FFT and FIR
- update build system to compile new kernels
- add doc describing wireless operations
- test FFT and FIR in unit test

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685fe5169f38832288a4844692c75bf6